### PR TITLE
Hotfixes - roundNumber updates, change in Parsing method

### DIFF
--- a/RoundGraph.go
+++ b/RoundGraph.go
@@ -98,8 +98,10 @@ func (g RoundGraph) setRounds(rounds []RoundStart, scores []ScoreUpdate, gameHal
 			if r.startTick <= s.tick && s.tick <= r.startTick+500 {
 				if s.team == "t" && s.score != r.t {
 					r.t = s.score
+					r.roundNumber = r.Total() + 1
 				} else if s.team == "ct" && s.score != r.ct {
 					r.ct = s.score
+					r.roundNumber = r.Total() + 1
 				}
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -58,17 +58,23 @@ func main() {
 		gameHalftimes = append(gameHalftimes, p.GameState().IngameTick())
 	})
 
-	// Parse to end
-	err = p.ParseToEnd()
-	if err != nil {
-		log.Panic("failed to parse demo: ", err)
+	// Parse as much of demo as possible
+	lastTick := 0
+	for ok, err := p.ParseNextFrame(); ok; ok, err = p.ParseNextFrame() {
+		if err != nil {
+			fmt.Printf("error while parsing demo: %v \n", err)
+		}
+
+		if lastTick < p.GameState().IngameTick() {
+			lastTick = p.GameState().IngameTick()
+		}
 	}
 
 	// Create round graph
 	rg := newRoundGraph()
 
 	// Set rg.rounds
-	rg.setRounds(roundStarts, scoreUpdates, gameHalftimes, p.Header().PlaybackTicks)
+	rg.setRounds(roundStarts, scoreUpdates, gameHalftimes, lastTick)
 
 	// Set edges for each node
 	rg.setEdges()


### PR DESCRIPTION
- RoundNumber updates when scores get updated
- Changed parsing method. This is because if demo throws any error (such as ErrUnexpectedEndOfDemo), we wouldn't have a last tick for the demo.